### PR TITLE
Refactor index registry

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -67,6 +67,5 @@ Indexes
 .. autosummary::
    :toctree: _api_generated/
 
-    indexes
-    register_index
     IndexAdapter
+    IndexRegistry

--- a/doc/examples/custom_indexes.ipynb
+++ b/doc/examples/custom_indexes.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Custom Indexes\n",
     "\n",
-    "While `xoak` provides some built-in index wrappers, it is easy to wrap and register new indexes. "
+    "While `xoak` provides some built-in index adapters, it is easy to adapt and register new indexes. "
    ]
   },
   {
@@ -24,7 +24,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This returns the list of built-in indexes in `xoak`:"
+    "An instance of `xoak.IndexRegistry` by default contains a collection of `xoak` built-in index adapters:"
    ]
   },
   {
@@ -33,18 +33,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "xoak.indexes"
+    "ireg = xoak.IndexRegistry()\n",
+    "\n",
+    "ireg"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Example: add a brute-force index\n",
+    "## Example: add a brute-force \"index\"\n",
     "\n",
-    "Every `xoak` supported index is a subclass of `xoak.IndexAdapter` that must implement the `build` and `query` methods. The `xoak.register_index` decorator may be used to register a new index.\n",
+    "Every `xoak` supported index is a subclass of `xoak.IndexAdapter` that must implement the `build` and `query` methods. The `IndexRegistry.register` decorator may be used to register a new index adpater.\n",
     "\n",
-    "Let's create and register a new \"index\", which simply performs brute-force nearest-neighbor lookup by computing the pairwise distances between all index and query points and finding the minimum distance. "
+    "Let's create and register a new adapter, which simply performs brute-force nearest-neighbor lookup by computing the pairwise distances between all index and query points and finding the minimum distance. "
    ]
   },
   {
@@ -56,8 +58,9 @@
     "from sklearn.metrics.pairwise import pairwise_distances_argmin_min\n",
     "\n",
     "\n",
-    "@xoak.register_index('brute_force')\n",
+    "@ireg.register('brute_force')\n",
     "class BruteForceIndex(xoak.IndexAdapter):\n",
+    "    \"\"\"Brute-force nearest neighbor lookup.\"\"\"\n",
     "    \n",
     "    def build(self, points):\n",
     "        # there is no index to build here, just return the points\n",
@@ -72,7 +75,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This new index now appears in the list of `xoak` registered indexes:"
+    "This new index now appears in the registry:"
    ]
   },
   {
@@ -81,7 +84,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "xoak.indexes"
+    "ireg"
    ]
   },
   {
@@ -110,7 +113,7 @@
     ")\n",
     "\n",
     "# set the brute-force index (doesn't really build any index in this case)\n",
-    "ds_mesh.xoak.set_index(['lat', 'lon'], 'brute_force')\n",
+    "ds_mesh.xoak.set_index(['lat', 'lon'], ireg['brute_force'])\n",
     "\n",
     "# create trajectory points\n",
     "ds_trajectory = xr.Dataset({\n",

--- a/environment_doc.yml
+++ b/environment_doc.yml
@@ -4,18 +4,15 @@ channels:
 dependencies:
   - python=3.8
   - numpy
-  - pandas
-  - dask
-  - xarray
   - scikit-learn
-  - ipykernel
-  - notebook
-  - ipykernel
   - matplotlib
-  - sphinx
-  - sphinx-autosummary-accessors
-  - sphinx_rtd_theme
-  - nbsphinx
   - pip
   - pip:
+      - ipykernel
+      - dask
+      - xarray
+      - sphinx
+      - sphinx-autosummary-accessors
+      - sphinx_rtd_theme
+      - nbsphinx
       - git+https://github.com/ESM-VFC/xoak

--- a/environment_doc.yml
+++ b/environment_doc.yml
@@ -3,16 +3,16 @@ channels:
   - conda-forge
 dependencies:
   - python=3.8
-  - numpy
-  - scikit-learn
-  - matplotlib
+  - dask=2.30.0
+  - ipykernel=5.4.2
+  - matplotlib=3.3.3
+  - nbsphinx=0.7.1
+  - numpy=1.19.4
+  - scikit-learn=0.23.2
+  - sphinx=3.3.1
+  - sphinx-autosummary-accessors=0.1.2
+  - sphinx_rtd_theme=0.5.0
+  - xarray=0.16.2
   - pip=20.3.1
   - pip:
-      - ipykernel
-      - dask
-      - xarray
-      - sphinx
-      - sphinx-autosummary-accessors
-      - sphinx_rtd_theme
-      - nbsphinx
       - git+https://github.com/ESM-VFC/xoak

--- a/environment_doc.yml
+++ b/environment_doc.yml
@@ -3,14 +3,14 @@ channels:
   - conda-forge
 dependencies:
   - python=3.8
-  - numpy
+  - numpy=1.19
   - scikit-learn
   - matplotlib
   - pip
   - pip:
       - ipykernel
       - dask
-      - xarray
+      - xarray=0.16.2
       - sphinx
       - sphinx-autosummary-accessors
       - sphinx_rtd_theme

--- a/environment_doc.yml
+++ b/environment_doc.yml
@@ -3,14 +3,14 @@ channels:
   - conda-forge
 dependencies:
   - python=3.8
-  - numpy=1.19
+  - numpy
   - scikit-learn
   - matplotlib
-  - pip
+  - pip=20.3.1
   - pip:
       - ipykernel
       - dask
-      - xarray=0.16.2
+      - xarray
       - sphinx
       - sphinx-autosummary-accessors
       - sphinx_rtd_theme

--- a/src/xoak/__init__.py
+++ b/src/xoak/__init__.py
@@ -1,7 +1,7 @@
 from pkg_resources import DistributionNotFound, get_distribution
 
 from .accessor import XoakAccessor
-from .index import IndexAdapter, indexes, register_index
+from .index import IndexAdapter, IndexRegistry
 
 try:
     __version__ = get_distribution(__name__).version

--- a/src/xoak/accessor.py
+++ b/src/xoak/accessor.py
@@ -85,8 +85,9 @@ class XoakAccessor:
         coords : iterable
             Coordinate names. Each given coordinate must have the same dimension(s),
             in the same order.
-        index_type : str or :class:`xoak.IndexWrapper` subclass
-            Either one of the registered index types or a custom index wrapper class.
+        index_type : str or :class:`~xoak.IndexAdapter` subclass
+            Either a registered index adapter (see :class:`~xoak.IndexRegistry`) or a custom
+            :class:`~xoak.IndexAdapter` subclass.
         persist: bool
             If True (default), this method will precompute and persist in memory the forest
             of index trees, if any.

--- a/src/xoak/index/__init__.py
+++ b/src/xoak/index/__init__.py
@@ -1,4 +1,4 @@
-from .base import IndexAdapter, indexes, register_index
+from .base import IndexAdapter, IndexRegistry
 
 try:
     from .balltree import BallTreeAdapter, GeoBallTreeAdapter

--- a/src/xoak/index/balltree.py
+++ b/src/xoak/index/balltree.py
@@ -1,10 +1,10 @@
 import numpy as np
 from sklearn.neighbors import BallTree
 
-from .base import IndexAdapter, register_index
+from .base import IndexAdapter, register_default
 
 
-@register_index('balltree')
+@register_default('balltree')
 class BallTreeAdapter(IndexAdapter):
     def __init__(self, **kwargs):
         self.index_options = kwargs
@@ -16,7 +16,7 @@ class BallTreeAdapter(IndexAdapter):
         return btree.query(points)
 
 
-@register_index('geo_balltree')
+@register_default('geo_balltree')
 class GeoBallTreeAdapter(IndexAdapter):
     def __init__(self, **kwargs):
         kwargs.update({'metric': 'haversine'})


### PR DESCRIPTION
Closes #21.

This is cleaner than having an `IndexRegistry` instance (i.e., `indexes`) globally exposed in xoak's scope.

Giving a string value for the `index_type` parameter of `Dataset.xoak.set_index()` is only possible for xoak's built-in index adapters, not anymore for dynamically registered indexes. But it's still possible to create and use `IndexRegistry` instances for convenience, which is more explicit by the way.
