### PR TITLE
Re-enable tests with pys2index on Linux

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,11 +38,7 @@ jobs:
           printenv | sort
       - name: Install dependencies
         shell: bash -l {0}
-        run: mamba install xarray dask numpy scipy scikit-learn pytest pytest-cov
-      - name: Install pys2index (MacOS, Windows)
-        if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest'
-        shell: bash -l {0}
-        run: mamba install pys2index
+        run: mamba install xarray dask numpy scipy scikit-learn pys2index pytest pytest-cov
       - name: Build and install xoak
         shell: bash -l {0}
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.6", "3.7", "3.8"]
+        python-version: ["3.6", "3.7", "3.8", "3.9"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/environment.yml
+++ b/environment.yml
@@ -5,10 +5,12 @@ dependencies:
   - python=3.8
   - numpy
   - pandas
+  - pys2index
   - dask
   - dask-labextension
   - xarray
   - scikit-learn
+  - scipy
   - jupyter
   - jupyterlab
   - notebook


### PR DESCRIPTION
The `pys2index` conda-forge packages have been rebuilt in https://github.com/conda-forge/pys2index-feedstock/pull/1.